### PR TITLE
feat: add React Tailwind dashboard prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# fraktionsbuero
+# Fraktionsbüro Dashboard Demo
+
+This repository contains a static React + Tailwind CSS prototype of the "Fraktionsbüro" dashboard.
+It showcases chats, upcoming meetings, a calendar, a task board and quick actions. All data is
+mocked on the client and no backend is required.
+
+## Development
+
+1. Install dependencies
+   ```
+   npm install
+   ```
+2. Start the development server
+   ```
+   npm run dev
+   ```
+3. Build for production
+   ```
+   npm run build
+   ```
+
+The project can be deployed to hosting services such as Vercel, Netlify or CodeSandbox.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fraktionsbüro</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fraktionsbuero",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "lucide-react": "^0.397.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.15"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import Header from './components/Header'
+import ChatTile from './components/ChatTile'
+import MeetingTile from './components/MeetingTile'
+import CalendarTile from './components/CalendarTile'
+import TaskBoard from './components/TaskBoard'
+import ActionTiles from './components/ActionTiles'
+import Modal from './components/Modal'
+
+const App: React.FC = () => {
+  const [modal, setModal] = useState<{ open: boolean; title: string }>({ open: false, title: '' })
+
+  const openModal = (title: string) => setModal({ open: true, title })
+  const closeModal = () => setModal({ open: false, title: '' })
+  const saveModal = () => closeModal()
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <Header onSettings={() => openModal('Einstellungen')} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+        <ChatTile onNew={() => openModal('Neuer Chat')} />
+        <MeetingTile onNew={() => openModal('Neue Sitzung')} />
+        <CalendarTile onNew={() => openModal('Neuer Kalendereintrag')} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2">
+          <TaskBoard onNew={() => openModal('Neue Aufgabe')} />
+        </div>
+        <ActionTiles onAction={(name) => openModal(name)} />
+      </div>
+
+      <Modal isOpen={modal.open} title={modal.title} onClose={closeModal} onSave={saveModal}>
+        <input type="text" placeholder="Titel" className="w-full mb-4 p-2 border rounded-lg" />
+        <textarea placeholder="Beschreibung" className="w-full p-2 border rounded-lg" />
+      </Modal>
+    </div>
+  )
+}
+
+export default App

--- a/src/components/ActionTiles.tsx
+++ b/src/components/ActionTiles.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Tile from './Tile'
+
+interface ActionTilesProps {
+  onAction: (name: string) => void
+}
+
+const actions = [
+  'Anfrage stellen',
+  'Antrag einreichen',
+  'Historie',
+  'Laufender Haushalt',
+  'Meine Dokumente',
+  'Fraktionsdokumente',
+  'Meine Reden',
+  'An Sitzung teilnehmen',
+]
+
+const ActionTiles: React.FC<ActionTilesProps> = ({ onAction }) => (
+  <Tile title="Schnellaktionen">
+    <div className="grid grid-cols-2 gap-3">
+      {actions.map((a) => (
+        <button
+          key={a}
+          className="p-3 rounded-lg bg-gray-100 hover:bg-gray-200 text-left"
+          onClick={() => onAction(a)}
+        >
+          {a}
+        </button>
+      ))}
+    </div>
+  </Tile>
+)
+
+export default ActionTiles

--- a/src/components/BoardColumn.tsx
+++ b/src/components/BoardColumn.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+interface BoardColumnProps {
+  title: string
+  items: string[]
+}
+
+const BoardColumn: React.FC<BoardColumnProps> = ({ title, items }) => (
+  <div className="bg-gray-100 rounded-xl p-3 flex-1 min-w-[150px]">
+    <h3 className="font-semibold mb-2">{title}</h3>
+    <ul className="space-y-2">
+      {items.map((i, idx) => (
+        <li key={idx} className="p-2 bg-white rounded-lg shadow">
+          {i}
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+export default BoardColumn

--- a/src/components/CalendarTile.tsx
+++ b/src/components/CalendarTile.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import Tile from './Tile'
+
+interface CalendarTileProps {
+  onNew: () => void
+}
+
+const CalendarTile: React.FC<CalendarTileProps> = ({ onNew }) => {
+  const days = Array.from({ length: 30 }, (_, i) => i + 1)
+
+  return (
+    <Tile title="Kalender" onNew={onNew}>
+      <div className="grid grid-cols-7 gap-1 text-center text-sm">
+        {days.map((d) => (
+          <div key={d} className="p-1 rounded-lg hover:bg-gray-200 cursor-pointer">
+            {d}
+          </div>
+        ))}
+      </div>
+    </Tile>
+  )
+}
+
+export default CalendarTile

--- a/src/components/ChatTile.tsx
+++ b/src/components/ChatTile.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import Tile from './Tile'
+
+interface ChatTileProps {
+  onNew: () => void
+}
+
+const ChatTile: React.FC<ChatTileProps> = ({ onNew }) => {
+  const chats = ['Fraktion intern', 'Finanzausschuss', 'Presse']
+
+  return (
+    <Tile title="Chats" onNew={onNew}>
+      <ul className="space-y-2">
+        {chats.map((c, i) => (
+          <li key={i} className="p-2 rounded-lg bg-gray-100">
+            {c}
+          </li>
+        ))}
+      </ul>
+    </Tile>
+  )
+}
+
+export default ChatTile

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Settings } from 'lucide-react'
+
+interface HeaderProps {
+  onSettings: () => void
+}
+
+const Header: React.FC<HeaderProps> = ({ onSettings }) => {
+  const date = new Date().toLocaleDateString('de-DE', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+
+  return (
+    <header className="flex items-center justify-between mb-6">
+      <div className="text-lg text-gray-600">{date}</div>
+      <h1 className="text-2xl font-bold">Fraktionsbüro</h1>
+      <button
+        className="p-2 rounded-full hover:bg-gray-200"
+        onClick={onSettings}
+        aria-label="Einstellungen"
+      >
+        <Settings className="w-6 h-6" />
+      </button>
+    </header>
+  )
+}
+
+export default Header

--- a/src/components/MeetingTile.tsx
+++ b/src/components/MeetingTile.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import Tile from './Tile'
+
+interface MeetingTileProps {
+  onNew: () => void
+}
+
+const MeetingTile: React.FC<MeetingTileProps> = ({ onNew }) => {
+  const meetings = [
+    { date: '12.10.2023', title: 'Fraktionssitzung' },
+    { date: '18.10.2023', title: 'Ratssitzung' },
+  ]
+
+  return (
+    <Tile title="Bevorstehende Sitzungen" onNew={onNew}>
+      <ul className="space-y-2">
+        {meetings.map((m, i) => (
+          <li key={i} className="p-2 rounded-lg bg-gray-100 flex justify-between">
+            <span>{m.title}</span>
+            <span className="text-sm text-gray-500">{m.date}</span>
+          </li>
+        ))}
+      </ul>
+    </Tile>
+  )
+}
+
+export default MeetingTile

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode } from 'react'
+
+interface ModalProps {
+  isOpen: boolean
+  title: string
+  children: ReactNode
+  onClose: () => void
+  onSave: () => void
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, title, children, onClose, onSave }) => {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+        <h2 className="text-xl font-semibold mb-4">{title}</h2>
+        <div className="mb-6">{children}</div>
+        <div className="flex justify-end space-x-3">
+          <button
+            className="px-4 py-2 rounded-lg bg-gray-200 hover:bg-gray-300"
+            onClick={onClose}
+          >
+            Abbrechen
+          </button>
+          <button
+            className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700"
+            onClick={onSave}
+          >
+            Speichern
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Modal

--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import Tile from './Tile'
+import BoardColumn from './BoardColumn'
+
+interface TaskBoardProps {
+  onNew: () => void
+}
+
+const TaskBoard: React.FC<TaskBoardProps> = ({ onNew }) => {
+  const todo = ['Protokoll schreiben', 'Budget prüfen']
+  const doing = ['Pressemitteilung']
+  const done = ['Antrag X']
+
+  return (
+    <Tile title="Aufgabenboard" onNew={onNew}>
+      <div className="flex space-x-4 overflow-x-auto">
+        <BoardColumn title="To-Do" items={todo} />
+        <BoardColumn title="In Bearbeitung" items={doing} />
+        <BoardColumn title="Erledigt" items={done} />
+      </div>
+    </Tile>
+  )
+}
+
+export default TaskBoard

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from 'react'
+
+interface TileProps {
+  title: string
+  onNew?: () => void
+  children: ReactNode
+}
+
+const Tile: React.FC<TileProps> = ({ title, onNew, children }) => (
+  <div className="bg-white rounded-2xl shadow p-4 flex flex-col h-full">
+    <div className="flex justify-between items-center mb-3">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      {onNew && (
+        <button
+          onClick={onNew}
+          className="px-3 py-1 rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700"
+        >
+          + Neu
+        </button>
+      )}
+    </div>
+    <div className="flex-1 overflow-auto">{children}</div>
+  </div>
+)
+
+export default Tile

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply text-gray-800;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})


### PR DESCRIPTION
## Summary
- scaffold Vite + React + Tailwind project for Fraktionsbüro dashboard prototype
- implement header, tiles, task board, quick actions and reusable modal
- document setup and development instructions

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6899eb5579ac83298129342222827e9f